### PR TITLE
Allow Helm values Passthrough

### DIFF
--- a/chart/templates/aws-load-balancer-controller.yaml
+++ b/chart/templates/aws-load-balancer-controller.yaml
@@ -9,17 +9,21 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: {{ .Values.repo_url }}
-    path: add-ons/aws-load-balancer-controller
-    targetRevision: HEAD
+    repoURL: https://aws.github.io/eks-charts
+    targetRevision: 1.4.1
+    chart: aws-load-balancer-controller
     helm: 
       parameters:
-      - name: aws-load-balancer-controller.clusterName
+      - name: clusterName
         value: {{ .Values.clusterName }}
-      - name: aws-load-balancer-controller.region
+      - name: region
         value: {{ .Values.region }}
-      - name: aws-load-balancer-controller.serviceAccount.name
+      - name: serviceAccount.name
         value: {{ .Values.awsLoadBalancerController.serviceAccountName }}
+  
+      values: |
+        {{- .Values.awsLoadBalancerController.rawValues | toYaml | trim | nindent 8 }}
+
   destination:
     server: https://kubernetes.default.svc
     namespace: kube-system

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -32,7 +32,13 @@ awsForFluentBit:
 # AWS Load Balancer Controller Values
 awsLoadBalancerController:
   enable: false
-  serviceAccountName:
+  # Values inserted in #rawValues will be pass-throughed to the chart
+  rawValues: 
+    replicaCount: 1
+    resources:
+      limits:
+        cpu: 200m
+        memory: 128Mi
 
 # AWS Otel Collector Values
 awsOtelCollector:


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/ssp-eks-add-ons/issues/21

*Description of changes:*

ArgoCD Application manifests supports referring to Helm charts directly. Refer to: https://argo-cd.readthedocs.io/en/stable/user-guide/helm/ and https://github.com/argoproj/argo-cd/blob/master/manifests/crds/application-crd.yaml . Versioning is also supported.

So instead of referring to the helm chart definition in the `addons` folder which will anyway refer to https://aws.github.io/eks-charts, I modified the `Application` definition to point directly to https://aws.github.io/eks-charts . In this manner, I can use `values` parameter to pass through any value definitions I want, without modifying any code.

As an added bonus, the addon in ArgoCD has Helm Chart icon instead of the usual Git icon :)

![image](https://user-images.githubusercontent.com/45155724/158795815-73268718-a919-458f-bc73-6c0debd30e69.png)


I've created an example using AWS Load Balancer Controller chart, but definitely this approach can be implemented in the rest of the charts too.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
