### PR TITLE
Fix/ niginx namespace change to match docs

### DIFF
--- a/chart/templates/ingress-nginx.yaml
+++ b/chart/templates/ingress-nginx.yaml
@@ -14,7 +14,7 @@ spec:
     targetRevision: HEAD
   destination:
     server: https://kubernetes.default.svc
-    namespace: nginx
+    namespace: ingress-nginx
   syncPolicy:
     automated:
       prune: true    


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
nginx is deploying to the incorrect namespace. Per the nginx docs it should deploy to ingress-nginx namespace

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
