### PR TITLE
Use Values.repo_url in the ArgoCD applications instead of hardcoded repo url

### DIFF
--- a/chart/templates/argo-rollouts.yaml
+++ b/chart/templates/argo-rollouts.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/aws-samples/eks-blueprints-add-ons
+    repoURL: {{ .Values.repo_url }}
     path: add-ons/argo-rollouts
     targetRevision: HEAD
   destination:

--- a/chart/templates/kube-state-metrics.yaml
+++ b/chart/templates/kube-state-metrics.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/aws-samples/eks-blueprints-add-ons
+    repoURL: {{ .Values.repo_url }}
     path: add-ons/kube-state-metrics
     targetRevision: HEAD
     helm:

--- a/chart/templates/kubernetes-dashboard.yaml
+++ b/chart/templates/kubernetes-dashboard.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/aws-samples/eks-blueprints-add-ons
+    repoURL: {{ .Values.repo_url }}
     path: add-ons/kubernetes-dashboard
     targetRevision: HEAD
     helm:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Use `Values.repo_url` in the ArgoCD applications instead of hardcoded repo url


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
