### PR TITLE
fix: adding new parameter to cloudwatch-metrics chart (serviceAccountName)

### DIFF
--- a/chart/templates/aws-cloudwatch-metrics.yaml
+++ b/chart/templates/aws-cloudwatch-metrics.yaml
@@ -16,6 +16,8 @@ spec:
       parameters:
       - name: aws-cloudwatch-metrics.clusterName
         value: {{ .Values.clusterName }}
+      - name: aws-cloudwatch-metrics.serviceAccount.name
+        value: {{ .Values.awsCloudWatchMetrics.serviceAccountName }}        
   destination:
     server: https://kubernetes.default.svc
     namespace: amazon-cloudwatch


### PR DESCRIPTION


*Issue #, if available:*
Fixes #45 
*Description of changes:*
Added ServiceAccountName chart parameter as it was missing and DS was not creating pods due to that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
