### PR TITLE
[LBC] Upgrade version to chart 1.4.2

### DIFF
--- a/add-ons/aws-load-balancer-controller/Chart.yaml
+++ b/add-ons/aws-load-balancer-controller/Chart.yaml
@@ -13,5 +13,5 @@ appVersion: "1.0"
 
 dependencies:
 - name: aws-load-balancer-controller
-  version: 1.3.2
+  version: 1.4.2
   repository: https://aws.github.io/eks-charts


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Upgrade The version of AWS load balancer controller to 1.4.2
This fixes the creation of the defaut ingressClass "alb" in the cluster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
