### PR TITLE
Updates for blueprint

### DIFF
--- a/add-ons/ondat/Chart.yaml
+++ b/add-ons/ondat/Chart.yaml
@@ -8,13 +8,13 @@ type: application
 
 # The chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.2.0
 
 # Version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: "2.6.0"
+appVersion: "2.7.0"
 
 dependencies:
-- name: ondat-operator
-  version: 0.5.5
+- name: ondat
+  version: 0.0.3
   repository: https://ondat.github.io/charts

--- a/add-ons/ondat/Chart.yaml
+++ b/add-ons/ondat/Chart.yaml
@@ -16,5 +16,5 @@ appVersion: "2.7.0"
 
 dependencies:
 - name: ondat
-  version: 0.0.3
+  version: 0.0.4
   repository: https://ondat.github.io/charts

--- a/add-ons/ondat/values.yaml
+++ b/add-ons/ondat/values.yaml
@@ -1,7 +1,19 @@
-ondat-operator:
-  cluster:
-    kvBackend:
-      address: https://storageos-etcd-client.storageos-etcd:2379
-    admin:
-      username: storageos
-      password: storageos
+ondat:
+  ondat-operator:
+    cluster:
+      kvBackend:
+        address: https://storageos-etcd.storageos-etcd:2379
+      admin:
+        username: storageos
+        password: storageos
+      nodeSelectorTerm: 
+        key: "storageos-node"
+        value: "1"
+  etcd-cluster-operator:
+    cluster:
+      replicas: 5
+      storage: 12Gi
+      storageclass: gp3
+      nodeSelectorTerm:
+        key: "storageos-etcd"
+        value: "1"

--- a/chart/templates/ondat.yaml
+++ b/chart/templates/ondat.yaml
@@ -15,42 +15,64 @@ spec:
     helm:
       parameters:
         {{- if .Values.ondat.serviceAccountName }}
-        - name: ondat-operator.serviceAccount.name
+        - name: ondat.ondat-operator.serviceAccount.name
           value: {{ .Values.ondat.serviceAccountName }}
         {{- end }}
         {{- if .Values.ondat.clusterSecretRefName }}
-        - name: ondat-operator.cluster.secretRefName
+        - name: ondat.ondat-operator.cluster.secretRefName
           value: {{ .Values.ondat.clusterSecretRefName }}
         {{- end }}
         {{- if .Values.ondat.clusterAdminUsername }}
-        - name: ondat-operator.cluster.admin.username
+        - name: ondat.ondat-operator.cluster.admin.username
           value: {{ .Values.ondat.clusterAdminUsername }}
         {{- end }}
         {{- if .Values.ondat.clusterAdminPassword }}
-        - name: ondat-operator.cluster.admin.password
+        - name: ondat.ondat-operator.cluster.admin.password
           value: {{ .Values.ondat.clusterAdminPassword }}
         {{- end }}
         {{- if .Values.ondat.clusterKvBackendAddress }}
-        - name: ondat-operator.cluster.kvBackend.address 
+        - name: ondat.ondat-operator.cluster.kvBackend.address 
           value: {{ .Values.ondat.clusterKvBackendAddress }}
         {{- end }}
         {{- if .Values.ondat.clusterNodeSelectorTermKey }}
-        - name: ondat-operator.cluster.nodeSelectorTerm.key
+        - name: ondat.ondat-operator.cluster.nodeSelectorTerm.key
           value: {{ .Values.ondat.clusterNodeSelectorTermKey }}
-        - name: ondat-operator.cluster.nodeSelectorTerm.value
+        - name: ondat.ondat-operator.cluster.nodeSelectorTerm.value
           value: {{ .Values.ondat.clusterNodeSelectorTermValue }}
         {{- end }}
         {{- if .Values.ondat.clusterKvBackendTLSSecretName }}
-        - name: ondat-operator.cluster.kvBackend.tlsSecretName
+        - name: ondat.ondat-operator.cluster.kvBackend.tlsSecretName
           value: {{ .Values.ondat.clusterKvBackendTLSSecretName }}
         {{- end }}
         {{- if .Values.ondat.clusterKvBackendTLSSecretNamespace }}
-        - name: ondat-operator.cluster.kvBackend.tlsSecretNamespace
+        - name: ondat.ondat-operator.cluster.kvBackend.tlsSecretNamespace
           value: {{ .Values.ondat.clusterKvBackendTLSSecretNamespace }}
+        {{- end }}
+        {{- if .Values.ondat.etcdClusterCreate }}
+        - name: ondat.etcd-cluster-operator.cluster.create
+          value: {{ .Values.ondat.etcdClusterCreate }}
+        {{- end }}
+        {{- if .Values.ondat.etcdClusterReplicas }}
+        - name: ondat.etcd-cluster-operator.cluster.replicas
+          value: {{ .Values.ondat.etcdClusterReplicas }}
+        {{- end }}
+        {{- if .Values.ondat.etcdClusterStorageclass }}
+        - name: ondat.etcd-cluster-operator.cluster.storageclass
+          value: {{ .Values.ondat.etcdClusterStorageclass }}
+        {{- end }}
+        {{- if .Values.ondat.etcdClusterStorage }}
+        - name: ondat.etcd-cluster-operator.cluster.storage
+          value: {{ .Values.ondat.etcdClusterStorage }}
+        {{- end }}
+        {{- if .Values.ondat.etcdNodeSelectorTermKey }}
+        - name: ondat.etcd-cluster-operator.cluster.nodeSelectorTerm.key
+          value: {{ .Values.ondat.etcdNodeSelectorTermKey }}
+        - name: ondat.etcd-cluster-operator.cluster.nodeSelectorTerm.value
+          value: {{ .Values.ondat.etcdNodeSelectorTermValue }}
         {{- end }}
   destination:
     server: https://kubernetes.default.svc
-    namespace: storageos
+    namespace: ondat
   syncPolicy:
     automated:
       prune: true
@@ -59,5 +81,5 @@ spec:
       backoff:
         duration: 5s
         factor: 2
-        maxDuration: 3m
+        maxDuration: 5m
 {{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -84,6 +84,7 @@ metricsServer:
 # Ondat Values
 ondat:
   enable: false
+  etcdClusterCreate: false
   serviceAccountName:
   clusterSecretRefName:
   clusterAdminUsername:
@@ -93,6 +94,12 @@ ondat:
   clusterKvBackendTLSSecretNamespace:
   clusterNodeSelectorTermKey:
   clusterNodeSelectorTermValue:
+  etcdNodeSelectorTermKey:
+  etcdNodeSelectorTermValue:
+  etcdClusterReplicas:
+  etcdClusterStorageclass:
+  etcdClusterStorage:
+
 
 # Prometheus Values
 prometheus:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This change includes several updates to the EKS Blueprint addon for Ondat:
* We now use an umbrella chart for installation of both Ondat and it's required etcd cluster
* Adds additional parameters, defaulting to a 'gp3' StorageClass for etcd with 12Gi PVC per node and 5 replicas targeted to nodes labelled `storageos-etcd=1`.

This is linked to the new release of 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
