### PR TITLE
chore: ALB helm parameters are already expanded with helm values, so they are not needed

### DIFF
--- a/chart/templates/aws-load-balancer-controller.yaml
+++ b/chart/templates/aws-load-balancer-controller.yaml
@@ -16,13 +16,6 @@ spec:
       values: |
         aws-load-balancer-controller:
         {{- toYaml .Values.awsLoadBalancerController | nindent 10 }}
-      parameters:
-      - name: aws-load-balancer-controller.clusterName
-        value: {{ .Values.clusterName }}
-      - name: aws-load-balancer-controller.region
-        value: {{ .Values.region }}
-      - name: aws-load-balancer-controller.serviceAccount.name
-        value: {{ .Values.awsLoadBalancerController.serviceAccountName }}
   destination:
     server: https://kubernetes.default.svc
     namespace: kube-system


### PR DESCRIPTION
set as https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/840