### PR TITLE
feat: enable selfHeal

### DIFF
--- a/chart/templates/agones.yaml
+++ b/chart/templates/agones.yaml
@@ -22,6 +22,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     syncOptions:
     - CreateNamespace=true
     retry:

--- a/chart/templates/appmesh-controller.yaml
+++ b/chart/templates/appmesh-controller.yaml
@@ -22,6 +22,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     syncOptions:
     - CreateNamespace=true
     retry:

--- a/chart/templates/argo-rollouts.yaml
+++ b/chart/templates/argo-rollouts.yaml
@@ -22,6 +22,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/aws-calico.yaml
+++ b/chart/templates/aws-calico.yaml
@@ -22,6 +22,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/aws-cloudwatch-metrics.yaml
+++ b/chart/templates/aws-cloudwatch-metrics.yaml
@@ -27,6 +27,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/aws-efs-csi-driver.yaml
+++ b/chart/templates/aws-efs-csi-driver.yaml
@@ -27,6 +27,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/aws-for-fluent-bit.yaml
+++ b/chart/templates/aws-for-fluent-bit.yaml
@@ -37,6 +37,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/aws-load-balancer-controller.yaml
+++ b/chart/templates/aws-load-balancer-controller.yaml
@@ -29,6 +29,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/aws-otel-collector.yaml
+++ b/chart/templates/aws-otel-collector.yaml
@@ -29,6 +29,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     syncOptions:
     - CreateNamespace=true
     retry:

--- a/chart/templates/cert-manager.yaml
+++ b/chart/templates/cert-manager.yaml
@@ -25,6 +25,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/cluster-autoscaler.yaml
+++ b/chart/templates/cluster-autoscaler.yaml
@@ -29,6 +29,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/external-dns.yaml
+++ b/chart/templates/external-dns.yaml
@@ -29,6 +29,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     syncOptions:
     - CreateNamespace=true
     retry:

--- a/chart/templates/external-secrets.yaml
+++ b/chart/templates/external-secrets.yaml
@@ -22,6 +22,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     syncOptions:
     - CreateNamespace=true
     retry:

--- a/chart/templates/gatekeeper.yaml
+++ b/chart/templates/gatekeeper.yaml
@@ -22,6 +22,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     syncOptions:
     - CreateNamespace=true
     retry:

--- a/chart/templates/ingress-nginx.yaml
+++ b/chart/templates/ingress-nginx.yaml
@@ -22,6 +22,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/karpenter.yaml
+++ b/chart/templates/karpenter.yaml
@@ -31,6 +31,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/keda.yaml
+++ b/chart/templates/keda.yaml
@@ -25,6 +25,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/kube-state-metrics.yaml
+++ b/chart/templates/kube-state-metrics.yaml
@@ -25,6 +25,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/kubernetes-dashboard.yaml
+++ b/chart/templates/kubernetes-dashboard.yaml
@@ -25,6 +25,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/metrics-server.yaml
+++ b/chart/templates/metrics-server.yaml
@@ -22,6 +22,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/ondat.yaml
+++ b/chart/templates/ondat.yaml
@@ -79,6 +79,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/prometheus.yaml
+++ b/chart/templates/prometheus.yaml
@@ -37,6 +37,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/spark-operator.yaml
+++ b/chart/templates/spark-operator.yaml
@@ -22,6 +22,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     syncOptions:
     - CreateNamespace=true
     retry:

--- a/chart/templates/tetrate-istio.yaml
+++ b/chart/templates/tetrate-istio.yaml
@@ -28,6 +28,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/traefik.yaml
+++ b/chart/templates/traefik.yaml
@@ -22,6 +22,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/vpa.yaml
+++ b/chart/templates/vpa.yaml
@@ -22,6 +22,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:

--- a/chart/templates/yunikorn.yaml
+++ b/chart/templates/yunikorn.yaml
@@ -22,6 +22,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
+      selfHeal: true
     retry:
       limit: 1
       backoff:


### PR DESCRIPTION
Some resources are always out of sync.
Enabling selfHeal is useful because it automatically synchronizes them.