### PR TITLE
chore: add enableArgocdFinalizers options

### DIFF
--- a/chart/templates/agones.yaml
+++ b/chart/templates/agones.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: agones
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/appmesh-controller.yaml
+++ b/chart/templates/appmesh-controller.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: appmesh-controller
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/argo-rollouts.yaml
+++ b/chart/templates/argo-rollouts.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: argo-rollouts
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/aws-calico.yaml
+++ b/chart/templates/aws-calico.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: aws-calico
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/aws-cloudwatch-metrics.yaml
+++ b/chart/templates/aws-cloudwatch-metrics.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: aws-cloudwatch-metrics
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/aws-efs-csi-driver.yaml
+++ b/chart/templates/aws-efs-csi-driver.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: aws-efs-csi-driver
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/aws-for-fluent-bit.yaml
+++ b/chart/templates/aws-for-fluent-bit.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: aws-for-fluent-bit
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/aws-load-balancer-controller.yaml
+++ b/chart/templates/aws-load-balancer-controller.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: aws-load-balancer-controller
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/aws-otel-collector.yaml
+++ b/chart/templates/aws-otel-collector.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: aws-otel-collector
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/cert-manager.yaml
+++ b/chart/templates/cert-manager.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: cert-manager
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/chaos-mesh.yaml
+++ b/chart/templates/chaos-mesh.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: chaos-mesh
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/cluster-autoscaler.yaml
+++ b/chart/templates/cluster-autoscaler.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: cluster-autoscaler
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/external-dns.yaml
+++ b/chart/templates/external-dns.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: external-dns
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/external-secrets.yaml
+++ b/chart/templates/external-secrets.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: external-secrets
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/gatekeeper.yaml
+++ b/chart/templates/gatekeeper.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: gatekeeper
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/ingress-nginx.yaml
+++ b/chart/templates/ingress-nginx.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: ingress-nginx
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/keda.yaml
+++ b/chart/templates/keda.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: keda
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/kube-state-metrics.yaml
+++ b/chart/templates/kube-state-metrics.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: kube-state-metrics
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/kubecost.yaml
+++ b/chart/templates/kubecost.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: kubecost
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/kubernetes-dashboard.yaml
+++ b/chart/templates/kubernetes-dashboard.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: kubernetes-dashboard
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/metrics-server.yaml
+++ b/chart/templates/metrics-server.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: metrics-server
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/prometheus.yaml
+++ b/chart/templates/prometheus.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: prometheus
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/promtail.yaml
+++ b/chart/templates/promtail.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: promtail
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/smb-sci-driver.yaml
+++ b/chart/templates/smb-sci-driver.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: smb-csi-driver
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/spark-operator.yaml
+++ b/chart/templates/spark-operator.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: spark-operator
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/tetrate-istio.yaml
+++ b/chart/templates/tetrate-istio.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: tetrate-istio
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/traefik.yaml
+++ b/chart/templates/traefik.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: traefik
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/vpa.yaml
+++ b/chart/templates/vpa.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: vpa
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/templates/yunikorn.yaml
+++ b/chart/templates/yunikorn.yaml
@@ -4,8 +4,10 @@ kind: Application
 metadata:
   name: yunikorn
   namespace: argocd
+  {{ if .Values.enableArgocdFinalizers }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
+  {{ end }}
 spec:
   project: default
   source:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,6 +5,8 @@ region: ""
 account: ""
 clusterName: ""
 
+enableArgocdFinalizers: true
+
 # Agones Values
 agones:
   enable: false
@@ -166,7 +168,7 @@ kubecost:
 # SMB CSI Driver Values
 smbCsiDriver:
   enable: false
-    
+
 # Chaos Mesh Values
 chaosMesh:
   enable: false


### PR DESCRIPTION
When migrating an Application, it may be inconvenient to have a finalizer attached.
Therefore, we have made it optional.