### PR TITLE
Makes aws load balancer controller works with EKS Blueprint Terraform

### DIFF
--- a/add-ons/aws-load-balancer-controller/Chart.yaml
+++ b/add-ons/aws-load-balancer-controller/Chart.yaml
@@ -13,5 +13,5 @@ appVersion: "1.0"
 
 dependencies:
 - name: aws-load-balancer-controller
-  version: 1.3.2
+  version: 1.4.2
   repository: https://aws.github.io/eks-charts

--- a/add-ons/aws-load-balancer-controller/Chart.yaml
+++ b/add-ons/aws-load-balancer-controller/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 
 # The chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.1
+version: 0.1.2
 
 # Version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -13,5 +13,5 @@ appVersion: "1.0"
 
 dependencies:
 - name: aws-load-balancer-controller
-  version: 1.4.2
+  version: 1.4.4
   repository: https://aws.github.io/eks-charts

--- a/add-ons/aws-load-balancer-controller/values.yaml
+++ b/add-ons/aws-load-balancer-controller/values.yaml
@@ -1,3 +1,4 @@
 aws-load-balancer-controller:
   serviceAccount:
     create: false
+  test: 'seb'

--- a/add-ons/aws-load-balancer-controller/values.yaml
+++ b/add-ons/aws-load-balancer-controller/values.yaml
@@ -1,4 +1,3 @@
 aws-load-balancer-controller:
   serviceAccount:
     create: false
-  test: 'seb'

--- a/add-ons/karpenter/Chart.yaml
+++ b/add-ons/karpenter/Chart.yaml
@@ -8,13 +8,13 @@ type: application
 
 # The chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.0
+version: 0.3.0
 
 # Version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: "1.0"
+appVersion: '1.0'
 
 dependencies:
-- name: karpenter
-  version: 0.10.0
-  repository: https://charts.karpenter.sh
+  - name: karpenter
+    version: 0.16.1
+    repository: https://charts.karpenter.sh

--- a/chart/templates/aws-load-balancer-controller.yaml
+++ b/chart/templates/aws-load-balancer-controller.yaml
@@ -17,7 +17,7 @@ spec:
         aws-load-balancer-controller:
           clusterName: {{ .Values.clusterName }}
           serviceAccount:
-            name: {{ .Values.awsLoadBalancerController.clusterName }}
+            name: {{ .Values.awsLoadBalancerController.serviceAccountName }}
             create: false
         {{- toYaml .Values.awsLoadBalancerController | nindent 10 }}
   destination:

--- a/chart/templates/aws-load-balancer-controller.yaml
+++ b/chart/templates/aws-load-balancer-controller.yaml
@@ -15,6 +15,10 @@ spec:
     helm:
       values: |
         aws-load-balancer-controller:
+          clusterName: {{ .Values.clusterName }}
+          serviceAccount:
+            name: {{ .Values.awsLoadBalancerController.clusterName }}
+            create: false
         {{- toYaml .Values.awsLoadBalancerController | nindent 10 }}
   destination:
     server: https://kubernetes.default.svc

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -37,8 +37,8 @@ awsForFluentBit:
 awsLoadBalancerController:
   enable: false
   serviceAccountName:
-  serviceAccount:
-    create: false
+  # serviceAccount:
+  #   create: false
   podDisruptionBudget:
     maxUnavailable: 1
   clusterName:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -39,7 +39,6 @@ awsLoadBalancerController:
   serviceAccountName:
   podDisruptionBudget:
     maxUnavailable: 1
-  clusterName:
 
 # AWS Otel Collector Values
 awsOtelCollector:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -36,9 +36,9 @@ awsForFluentBit:
 # AWS Load Balancer Controller Values
 awsLoadBalancerController:
   enable: false
-  serviceAccountName:
-  # serviceAccount:
-  #   create: false
+  serviceAccount:
+    create: false
+    name:
   podDisruptionBudget:
     maxUnavailable: 1
   clusterName:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -36,9 +36,7 @@ awsForFluentBit:
 # AWS Load Balancer Controller Values
 awsLoadBalancerController:
   enable: false
-  serviceAccount:
-    create: false
-    name:
+  serviceAccountName:
   podDisruptionBudget:
     maxUnavailable: 1
   clusterName:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,9 +1,9 @@
 # Global Values
-repoUrl: "https://github.com/aws-samples/eks-blueprints-add-ons.git"
+repoUrl: 'https://github.com/aws-samples/eks-blueprints-add-ons.git'
 targetRevision: HEAD
-region: ""
-account: ""
-clusterName: ""
+region: ''
+account: ''
+clusterName: ''
 
 # Agones Values
 agones:
@@ -37,6 +37,8 @@ awsForFluentBit:
 awsLoadBalancerController:
   enable: false
   serviceAccountName:
+  serviceAccount:
+    create: false
   podDisruptionBudget:
     maxUnavailable: 1
   clusterName:
@@ -110,7 +112,6 @@ ondat:
   etcdClusterStorageclass:
   etcdClusterStorage:
 
-
 # Prometheus Values
 prometheus:
   enable: false
@@ -167,7 +168,7 @@ kubecost:
 # SMB CSI Driver Values
 smbCsiDriver:
   enable: false
-    
+
 # Chaos Mesh Values
 chaosMesh:
   enable: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -38,7 +38,8 @@ awsLoadBalancerController:
   enable: false
   serviceAccountName:
   podDisruptionBudget:
-    maxUnavailable: '1'
+    maxUnavailable: 1
+  clusterName:
 
 # AWS Otel Collector Values
 awsOtelCollector:


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/935

*Description of changes:*
- upgrade load balancer controller chart version, and Karpenter chart version
- add clusterName as it is needed by lbc chart
- add mapping from serviceAccountName send by Terraform to serviceAccount.name needed by the chart
- fix PRB issue with lbc as it needs integer and not string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
