### PR TITLE
Fix mapped miss

### DIFF
--- a/chart/templates/aws-load-balancer-controller.yaml
+++ b/chart/templates/aws-load-balancer-controller.yaml
@@ -16,6 +16,7 @@ spec:
       values: |
         aws-load-balancer-controller:
           clusterName: {{ .Values.clusterName }}
+          region: {{ .Values.region }}
           serviceAccount:
             name: {{ .Values.awsLoadBalancerController.serviceAccountName }}
             create: false


### PR DESCRIPTION
terraform-aws-eks-blueprints only passes values at one level.

Currently I get this error.
> Chart cannot be installed without a valid clusterName! Use --debug flag to render out invalid YAML
