### PR TITLE
feat: Adding Grafana Helm Chart

### DIFF
--- a/add-ons/grafana/Chart.yaml
+++ b/add-ons/grafana/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: grafana
+description: A Helm chart for Grafana
+
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+type: application
+
+# The chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# Version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: "1.0"
+
+dependencies:
+- name: grafana
+  version: 6.32.1
+  repository: "https://grafana.github.io/helm-charts"

--- a/add-ons/grafana/Chart.yaml
+++ b/add-ons/grafana/Chart.yaml
@@ -16,5 +16,5 @@ appVersion: "1.0"
 
 dependencies:
 - name: grafana
-  version: 6.32.1
+  version: 6.38.6
   repository: "https://grafana.github.io/helm-charts"

--- a/add-ons/grafana/values.yaml
+++ b/add-ons/grafana/values.yaml
@@ -1,4 +1,5 @@
 # for details on all options
 # https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
+
 serviceAccount:
   create: false

--- a/add-ons/grafana/values.yaml
+++ b/add-ons/grafana/values.yaml
@@ -1,0 +1,4 @@
+# for details on all options
+# https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
+serviceAccount:
+  create: false

--- a/chart/templates/grafana.yaml
+++ b/chart/templates/grafana.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.grafana).enable) }} 
+{{- if ((.Values.grafana).enable) }} 
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/chart/templates/grafana.yaml
+++ b/chart/templates/grafana.yaml
@@ -1,0 +1,34 @@
+{{- if and (.Values.grafana) (.Values.grafana.enable) -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: grafana
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: {{ .Values.repoUrl }}
+    path: add-ons/grafana
+    targetRevision: {{ .Values.targetRevision }}
+    helm:
+      values: |
+        grafana:
+        {{- toYaml .Values.grafana | nindent 10 }}
+      parameters:
+        - name: grafana.serviceAccount.name
+          value: {{ .Values.grafana.serviceAccountName }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: grafana
+  syncPolicy:
+    automated:
+      prune: true
+    retry:
+      limit: 1
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+  {{- end -}}

--- a/chart/templates/grafana.yaml
+++ b/chart/templates/grafana.yaml
@@ -14,7 +14,7 @@ spec:
     targetRevision: {{ .Values.targetRevision }}
     helm:
       values: |
-        {{- toYaml .Values.grafana | nindent 10 }}
+        {{- toYaml .Values.grafana | nindent 8 }}
       parameters:
         - name: grafana.serviceAccount.name
           value: {{ .Values.grafana.serviceAccountName }}

--- a/chart/templates/grafana.yaml
+++ b/chart/templates/grafana.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.grafana) (.Values.grafana.enable) -}}
+{{- if (.Values.grafana).enable) }} 
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -9,7 +9,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: {{ .Values.repoUrl }}
+    repoURL: {{ required "repoUrl value is required" .Values.repoUrl }}
     path: add-ons/grafana
     targetRevision: {{ .Values.targetRevision }}
     helm:

--- a/chart/templates/grafana.yaml
+++ b/chart/templates/grafana.yaml
@@ -14,7 +14,6 @@ spec:
     targetRevision: {{ .Values.targetRevision }}
     helm:
       values: |
-        grafana:
         {{- toYaml .Values.grafana | nindent 10 }}
       parameters:
         - name: grafana.serviceAccount.name

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -79,6 +79,12 @@ gatekeeper:
 ingressNginx:
   enable: false
 
+# Grafana default Values
+grafana:
+  enable: false
+  serviceAccount:
+    create: false
+
 # Karpenter Values
 karpenter:
   enable: false


### PR DESCRIPTION
Closes #84 

**Description of changes:**
When enabling the Grafana add-on in terraform, the chart never got deployed, only related IAM resources listed below.  This PR adds the Grafana `Chart` and `add-on` definitions.

```
➜ terraform state list | grep grafana
module.kubernetes-addons.module.grafana[0].data.aws_iam_policy_document.this
module.kubernetes-addons.module.grafana[0].aws_iam_policy.grafana
module.kubernetes-addons.module.grafana[0].module.helm_addon.module.irsa[0].aws_iam_role.irsa[0]
module.kubernetes-addons.module.grafana[0].module.helm_addon.module.irsa[0].aws_iam_role_policy_attachment.irsa[0]
module.kubernetes-addons.module.grafana[0].module.helm_addon.module.irsa[0].kubernetes_namespace_v1.irsa[0]
module.kubernetes-addons.module.grafana[0].module.helm_addon.module.irsa[0].kubernetes_service_account_v1.irsa[0]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
