### PR TITLE
Fix kubecost helm chart repo url

### DIFF
--- a/add-ons/kubecost/Chart.yaml
+++ b/add-ons/kubecost/Chart.yaml
@@ -17,4 +17,4 @@ appVersion: "1.0"
 dependencies:
   - name: cost-analyzer
     version: 1.96.0
-    repository: oci://public.ecr.aws/kubecost/cost-analyzer
+    repository: oci://public.ecr.aws/kubecost


### PR DESCRIPTION
Resolves #95 

*Description of changes:*

Removing the "/cost-analyzer" string that should not be present in the kubecost helm chart repo URL.
