### PR TITLE
chore(aws-load-balancer-controller featureGates): disable SubnetsClusterTagCheck

### DIFF
--- a/add-ons/aws-load-balancer-controller/values.yaml
+++ b/add-ons/aws-load-balancer-controller/values.yaml
@@ -1,3 +1,6 @@
 aws-load-balancer-controller:
   serviceAccount:
     create: false
+  controllerConfig:
+    featureGates:
+      SubnetsClusterTagCheck: false


### PR DESCRIPTION
If you do not need this feature, I would like to disable it.
https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/852#issuecomment-1296026824