### PR TITLE
add aws-node-termination-handler add-on

### DIFF
--- a/add-ons/aws-node-termination-handler/Chart.yaml
+++ b/add-ons/aws-node-termination-handler/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: aws-node-termination-handler
+description: A Helm chart for installing the AWS Node Termination Handler
+
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+type: application
+
+# The chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# Version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: "1.0"
+
+dependencies:
+- name: aws-node-termination-handler
+  version: 0.20.1
+  repository: https://aws.github.io/eks-charts

--- a/add-ons/aws-node-termination-handler/values.yaml
+++ b/add-ons/aws-node-termination-handler/values.yaml
@@ -1,0 +1,3 @@
+aws-node-termination-handler:
+  serviceAccount:
+    create: false

--- a/chart/templates/aws-node-termination-handler.yaml
+++ b/chart/templates/aws-node-termination-handler.yaml
@@ -1,0 +1,31 @@
+{{- if and (.Values.awsNodeTerminationHandler) (.Values.awsNodeTerminationHandler.enable) -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: aws-node-termination-handler
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: {{ .Values.repoUrl }}
+    path: add-ons/aws-node-termination-handler
+    targetRevision: {{ .Values.targetRevision }}
+    helm:
+      values: |
+        awsNodeTerminationHandler:
+        {{- toYaml .Values.awsNodeTerminationHandler | nindent 10 }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+    retry:
+      limit: 1
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+{{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -40,6 +40,11 @@ awsLoadBalancerController:
   podDisruptionBudget:
     maxUnavailable: 1
 
+# AWS Node Termination Handler Values
+awsNodeTerminationHandler:
+  enable: false
+  serviceAccountName:
+
 # AWS Otel Collector Values
 awsOtelCollector:
   enable: false
@@ -59,7 +64,7 @@ certManagerCsiDriver:
 clusterAutoscaler:
   enable: false
   serviceAccountName:
-    
+
 # Datadog Operator
 datadogOperator:
   enable: false
@@ -214,7 +219,7 @@ policies:
 
 reporter:
   enable: false
-  
+
 # NVIDIA Device Plugin Values
 nvidiaDevicePlugin:
   enable: false


### PR DESCRIPTION
*Issue #, if available:*
Adds AWS Node Termination Handler add-on as per - https://github.com/aws-samples/eks-blueprints-add-ons/issues/32

*Description of changes:*
Brings enablement for AWS Node Termination Handler to be managed via EKS Blueprints GitOps mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
