### PR TITLE
fix: Use Velero values instead of Traefik

### DIFF
--- a/chart/templates/velero.yaml
+++ b/chart/templates/velero.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.traefik) (.Values.traefik.enable) -}}
+{{- if and (.Values.velero) (.Values.velero.enable) -}}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- use velero values instead of traefik for velero app.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
