### PR TITLE
fix(strimzi-kafka-operator): Create namespace

### DIFF
--- a/chart/templates/strimzi-kafka-operator.yaml
+++ b/chart/templates/strimzi-kafka-operator.yaml
@@ -22,6 +22,8 @@ spec:
   syncPolicy:
     automated:
       prune: true
+    syncOptions:
+    - CreateNamespace=true
     retry:
       limit: 1
       backoff:


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-samples/eks-blueprints-add-ons/issues/130

*Description of changes:*

This will tell ArgoCD to create a namespace for the `strimzi-kafka-operator` resources, which needs to be done in order for ArgoCD to sync correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
