### PR TITLE
fix(vault): vault values cannot pass to helm template

### DIFF
--- a/add-ons/vault/values.yaml
+++ b/add-ons/vault/values.yaml
@@ -1,2 +1,7 @@
 # for details on all options
 # https://github.com/hashicorp/vault-helm/blob/main/values.yaml
+vault:
+  global:
+    # enabled is the master enabled switch. Setting this to true or false
+    # will enable or disable all the components within this chart by default.
+    enabled: true

--- a/chart/templates/vault.yaml
+++ b/chart/templates/vault.yaml
@@ -14,7 +14,8 @@ spec:
     targetRevision: {{ .Values.targetRevision }}
     helm:
       values: |
-        {{- toYaml .Values.vault | nindent 8 }}
+        vault:
+        {{- toYaml .Values.vault | nindent 10 }}
   destination:
     server: https://kubernetes.default.svc
     namespace: vault

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -111,6 +111,9 @@ grafana:
 # Vault default Values
 vault:
   enable: false
+  server:
+    dataStorage:
+      enabled: true
 
 # Karpenter Values
 karpenter:


### PR DESCRIPTION
*Issue #, if available:*
whatever we configure the vault's values. The values cannot pass to the helm chart.

*Description of changes:*
update missing vault values in the vault add-on and fix the yaml indent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
