### PR TITLE
Allow to pass more argocd variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ spec:
         metrics-server:
           enable: true
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: argocd
 ```
 

--- a/chart/templates/agones.yaml
+++ b/chart/templates/agones.yaml
@@ -17,7 +17,7 @@ spec:
         agones:
         {{- toYaml .Values.agones | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: agones-system
   syncPolicy:
     automated:

--- a/chart/templates/agones.yaml
+++ b/chart/templates/agones.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/agones

--- a/chart/templates/agones.yaml
+++ b/chart/templates/agones.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: agones
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/appmesh-controller.yaml
+++ b/chart/templates/appmesh-controller.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/appmesh-controller

--- a/chart/templates/appmesh-controller.yaml
+++ b/chart/templates/appmesh-controller.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: appmesh-controller
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/appmesh-controller.yaml
+++ b/chart/templates/appmesh-controller.yaml
@@ -17,7 +17,7 @@ spec:
         appmesh-controller:
         {{- toYaml .Values.appMesh | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: appmesh-system
   syncPolicy:
     automated:

--- a/chart/templates/argo-rollouts.yaml
+++ b/chart/templates/argo-rollouts.yaml
@@ -17,7 +17,7 @@ spec:
         argo-rollouts:
         {{- toYaml .Values.argoRollouts | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: argo-rollouts
   syncPolicy:
     automated:

--- a/chart/templates/argo-rollouts.yaml
+++ b/chart/templates/argo-rollouts.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/argo-rollouts

--- a/chart/templates/argo-rollouts.yaml
+++ b/chart/templates/argo-rollouts.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: argo-rollouts
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/argo-workflows.yaml
+++ b/chart/templates/argo-workflows.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/argo-workflows

--- a/chart/templates/argo-workflows.yaml
+++ b/chart/templates/argo-workflows.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: argo-workflows
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/argo-workflows.yaml
+++ b/chart/templates/argo-workflows.yaml
@@ -17,7 +17,7 @@ spec:
         argo-workflows:
         {{- toYaml .Values.argoWorkflows | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: argo-workflows
   syncPolicy:
     automated:

--- a/chart/templates/aws-cloudwatch-metrics.yaml
+++ b/chart/templates/aws-cloudwatch-metrics.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: aws-cloudwatch-metrics
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/aws-cloudwatch-metrics.yaml
+++ b/chart/templates/aws-cloudwatch-metrics.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/aws-cloudwatch-metrics

--- a/chart/templates/aws-cloudwatch-metrics.yaml
+++ b/chart/templates/aws-cloudwatch-metrics.yaml
@@ -22,7 +22,7 @@ spec:
       - name: aws-cloudwatch-metrics.serviceAccount.name
         value: {{ .Values.awsCloudWatchMetrics.serviceAccountName }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: amazon-cloudwatch
   syncPolicy:
     automated:

--- a/chart/templates/aws-efs-csi-driver.yaml
+++ b/chart/templates/aws-efs-csi-driver.yaml
@@ -22,7 +22,7 @@ spec:
       - name: aws-efs-csi-driver.node.serviceAccount.name
         value: {{ .Values.awsEfsCsiDriver.serviceAccountName }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: kube-system
   syncPolicy:
     automated:

--- a/chart/templates/aws-efs-csi-driver.yaml
+++ b/chart/templates/aws-efs-csi-driver.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: aws-efs-csi-driver
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/aws-efs-csi-driver.yaml
+++ b/chart/templates/aws-efs-csi-driver.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/aws-efs-csi-driver

--- a/chart/templates/aws-for-fluent-bit.yaml
+++ b/chart/templates/aws-for-fluent-bit.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: aws-for-fluent-bit
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/aws-for-fluent-bit.yaml
+++ b/chart/templates/aws-for-fluent-bit.yaml
@@ -32,7 +32,7 @@ spec:
       - name: aws-for-fluent-bit.elasticsearch.region
         value: {{ .Values.region }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: aws-for-fluent-bit
   syncPolicy:
     automated:

--- a/chart/templates/aws-for-fluent-bit.yaml
+++ b/chart/templates/aws-for-fluent-bit.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/aws-for-fluent-bit

--- a/chart/templates/aws-load-balancer-controller.yaml
+++ b/chart/templates/aws-load-balancer-controller.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: {{ .Values.clusterName }}-aws-load-balancer-controller
+  name: aws-load-balancer-controller
   namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io

--- a/chart/templates/aws-load-balancer-controller.yaml
+++ b/chart/templates/aws-load-balancer-controller.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/aws-load-balancer-controller

--- a/chart/templates/aws-load-balancer-controller.yaml
+++ b/chart/templates/aws-load-balancer-controller.yaml
@@ -22,7 +22,7 @@ spec:
             create: false
         {{- toYaml .Values.awsLoadBalancerController | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: kube-system
   syncPolicy:
     automated:

--- a/chart/templates/aws-load-balancer-controller.yaml
+++ b/chart/templates/aws-load-balancer-controller.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: {{ .Values.clusterName }}-aws-load-balancer-controller
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/aws-load-balancer-controller.yaml
+++ b/chart/templates/aws-load-balancer-controller.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: aws-load-balancer-controller
+  name: {{ .Values.clusterName }}-aws-load-balancer-controller
   namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io

--- a/chart/templates/aws-load-balancer-controller.yaml
+++ b/chart/templates/aws-load-balancer-controller.yaml
@@ -29,10 +29,15 @@ spec:
       prune: true
     syncOptions:
       - CreateNamespace={{ .Values.awsLoadBalancerController.createNamespace }}
+      - RespectIgnoreDifferences={{ .Values.awsLoadBalancerController.respectIgnoreDifferences }}
     retry:
       limit: 1
       backoff:
         duration: 5s
         factor: 2
         maxDuration: 1m
+  {{- with .Values.awsLoadBalancerController.ignoreDifferences }}
+  ignoreDifferences:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/chart/templates/aws-node-termination-handler.yaml
+++ b/chart/templates/aws-node-termination-handler.yaml
@@ -17,7 +17,7 @@ spec:
         awsNodeTerminationHandler:
         {{- toYaml .Values.awsNodeTerminationHandler | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: kube-system
   syncPolicy:
     automated:

--- a/chart/templates/aws-node-termination-handler.yaml
+++ b/chart/templates/aws-node-termination-handler.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/aws-node-termination-handler

--- a/chart/templates/aws-node-termination-handler.yaml
+++ b/chart/templates/aws-node-termination-handler.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: aws-node-termination-handler
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/aws-otel-collector.yaml
+++ b/chart/templates/aws-otel-collector.yaml
@@ -24,7 +24,7 @@ spec:
       - name: aws-otel-collector.resourceAttributes
         value: {{ .Values.awsOtelCollector.resourceAttributes }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: aws-otel-eks
   syncPolicy:
     automated:

--- a/chart/templates/aws-otel-collector.yaml
+++ b/chart/templates/aws-otel-collector.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: aws-otel-collector
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/aws-otel-collector.yaml
+++ b/chart/templates/aws-otel-collector.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/aws-otel-collector

--- a/chart/templates/calico.yaml
+++ b/chart/templates/calico.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/calico

--- a/chart/templates/calico.yaml
+++ b/chart/templates/calico.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: calico
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/calico.yaml
+++ b/chart/templates/calico.yaml
@@ -17,7 +17,7 @@ spec:
         calico:
         {{- toYaml .Values.calico | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: kube-system
   syncPolicy:
     automated:

--- a/chart/templates/cert-manager-csi-driver.yaml
+++ b/chart/templates/cert-manager-csi-driver.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/cert-manager

--- a/chart/templates/cert-manager-csi-driver.yaml
+++ b/chart/templates/cert-manager-csi-driver.yaml
@@ -17,7 +17,7 @@ spec:
         cert-manager-csi-driver:
         {{- toYaml .Values.certManagerCsiDriver | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: cert-manager
   syncPolicy:
     automated:

--- a/chart/templates/cert-manager-csi-driver.yaml
+++ b/chart/templates/cert-manager-csi-driver.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: cert-manager-csi-driver
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/cert-manager.yaml
+++ b/chart/templates/cert-manager.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/cert-manager

--- a/chart/templates/cert-manager.yaml
+++ b/chart/templates/cert-manager.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: cert-manager
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/cert-manager.yaml
+++ b/chart/templates/cert-manager.yaml
@@ -20,7 +20,7 @@ spec:
       - name: cert-manager.serviceAccount.name
         value: {{ .Values.certManager.serviceAccountName }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: cert-manager
   syncPolicy:
     automated:

--- a/chart/templates/chaos-mesh.yaml
+++ b/chart/templates/chaos-mesh.yaml
@@ -17,7 +17,7 @@ spec:
         chaos-mesh:
         {{- toYaml .Values.chaosMesh | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: chaos-testing
   syncPolicy:
     automated:

--- a/chart/templates/chaos-mesh.yaml
+++ b/chart/templates/chaos-mesh.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: chaos-mesh
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/chaos-mesh.yaml
+++ b/chart/templates/chaos-mesh.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/chaos-mesh

--- a/chart/templates/cilium.yaml
+++ b/chart/templates/cilium.yaml
@@ -17,7 +17,7 @@ spec:
         cilium:
         {{- toYaml .Values.cilium | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: kube-system
   syncPolicy:
     automated:

--- a/chart/templates/cilium.yaml
+++ b/chart/templates/cilium.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: cilium
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/cilium.yaml
+++ b/chart/templates/cilium.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/cilium

--- a/chart/templates/cluster-autoscaler.yaml
+++ b/chart/templates/cluster-autoscaler.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/cluster-autoscaler

--- a/chart/templates/cluster-autoscaler.yaml
+++ b/chart/templates/cluster-autoscaler.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: cluster-autoscaler
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/cluster-autoscaler.yaml
+++ b/chart/templates/cluster-autoscaler.yaml
@@ -24,7 +24,7 @@ spec:
       - name: cluster-autoscaler.autoDiscovery.clusterName
         value: {{ .Values.clusterName }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: kube-system
   syncPolicy:
     automated:

--- a/chart/templates/consul.yaml
+++ b/chart/templates/consul.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/consul

--- a/chart/templates/consul.yaml
+++ b/chart/templates/consul.yaml
@@ -17,7 +17,7 @@ spec:
         consul:
         {{- toYaml .Values.consul | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: consul
   syncPolicy:
     automated:

--- a/chart/templates/consul.yaml
+++ b/chart/templates/consul.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: consul
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/datadog-operator.yaml
+++ b/chart/templates/datadog-operator.yaml
@@ -17,7 +17,7 @@ spec:
         datadog-operator:
         {{- toYaml .Values.datadogOperator | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: datadog-operator
   syncPolicy:
     automated:

--- a/chart/templates/datadog-operator.yaml
+++ b/chart/templates/datadog-operator.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: datadog-operator
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/datadog-operator.yaml
+++ b/chart/templates/datadog-operator.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/datadog-operator

--- a/chart/templates/external-dns.yaml
+++ b/chart/templates/external-dns.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: external-dns
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/external-dns.yaml
+++ b/chart/templates/external-dns.yaml
@@ -24,7 +24,7 @@ spec:
       - name: external-dns.zoneIdFilters[0]
         value: {{ .Values.externalDns.zoneIdFilter }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: external-dns
   syncPolicy:
     automated:

--- a/chart/templates/external-dns.yaml
+++ b/chart/templates/external-dns.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/external-dns

--- a/chart/templates/external-secrets.yaml
+++ b/chart/templates/external-secrets.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: external-secrets
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/external-secrets.yaml
+++ b/chart/templates/external-secrets.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/external-secrets

--- a/chart/templates/external-secrets.yaml
+++ b/chart/templates/external-secrets.yaml
@@ -17,7 +17,7 @@ spec:
         external-secrets:
         {{- toYaml .Values.externalSecrets | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: external-secrets
   syncPolicy:
     automated:

--- a/chart/templates/gatekeeper.yaml
+++ b/chart/templates/gatekeeper.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: gatekeeper
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/gatekeeper.yaml
+++ b/chart/templates/gatekeeper.yaml
@@ -17,7 +17,7 @@ spec:
         gatekeeper:
         {{- toYaml .Values.gatekeeper | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: gatekeeper-system
   syncPolicy:
     automated:

--- a/chart/templates/gatekeeper.yaml
+++ b/chart/templates/gatekeeper.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/gatekeeper

--- a/chart/templates/grafana.yaml
+++ b/chart/templates/grafana.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ required "repoUrl value is required" .Values.repoUrl }}
     path: add-ons/grafana

--- a/chart/templates/grafana.yaml
+++ b/chart/templates/grafana.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: grafana
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/grafana.yaml
+++ b/chart/templates/grafana.yaml
@@ -19,7 +19,7 @@ spec:
         - name: grafana.serviceAccount.name
           value: {{ .Values.grafana.serviceAccountName }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: grafana
   syncPolicy:
     automated:

--- a/chart/templates/ingress-nginx.yaml
+++ b/chart/templates/ingress-nginx.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/ingress-nginx

--- a/chart/templates/ingress-nginx.yaml
+++ b/chart/templates/ingress-nginx.yaml
@@ -17,7 +17,7 @@ spec:
         ingress-nginx:
         {{- toYaml .Values.ingressNginx | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: ingress-nginx
   syncPolicy:
     automated:

--- a/chart/templates/ingress-nginx.yaml
+++ b/chart/templates/ingress-nginx.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: ingress-nginx
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/karpenter.yaml
+++ b/chart/templates/karpenter.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/karpenter

--- a/chart/templates/karpenter.yaml
+++ b/chart/templates/karpenter.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: karpenter
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/karpenter.yaml
+++ b/chart/templates/karpenter.yaml
@@ -28,7 +28,7 @@ spec:
         - name: karpenter.settings.aws.interruptionQueueName
           value: {{ .Values.karpenter.awsInterruptionQueueName }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: karpenter
   syncPolicy:
     automated:

--- a/chart/templates/keda.yaml
+++ b/chart/templates/keda.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/keda

--- a/chart/templates/keda.yaml
+++ b/chart/templates/keda.yaml
@@ -20,7 +20,7 @@ spec:
       - name: keda.serviceAccount.name
         value: {{ .Values.keda.serviceAccountName }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: keda
   syncPolicy:
     automated:

--- a/chart/templates/keda.yaml
+++ b/chart/templates/keda.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: keda
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/kube-prometheus-stack.yaml
+++ b/chart/templates/kube-prometheus-stack.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: kube-prometheus-stack
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/kube-prometheus-stack.yaml
+++ b/chart/templates/kube-prometheus-stack.yaml
@@ -22,7 +22,7 @@ spec:
               serviceMonitorSelectorNilUsesHelmValues: false
         {{- toYaml .Values.kubePrometheusStack | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: kube-prometheus-stack
   syncPolicy:
     automated:

--- a/chart/templates/kube-prometheus-stack.yaml
+++ b/chart/templates/kube-prometheus-stack.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: https://github.com/aws-samples/eks-blueprints-add-ons
     path: add-ons/kube-prometheus-stack

--- a/chart/templates/kube-state-metrics.yaml
+++ b/chart/templates/kube-state-metrics.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/kube-state-metrics

--- a/chart/templates/kube-state-metrics.yaml
+++ b/chart/templates/kube-state-metrics.yaml
@@ -20,7 +20,7 @@ spec:
       - name: kube-state-metrics.serviceAccount.name
         value: {{ .Values.kubeStateMetrics.serviceAccountName }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: kube-state-metrics
   syncPolicy:
     automated:

--- a/chart/templates/kube-state-metrics.yaml
+++ b/chart/templates/kube-state-metrics.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: kube-state-metrics
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/kubecost.yaml
+++ b/chart/templates/kubecost.yaml
@@ -17,7 +17,7 @@ spec:
         kubecost:
         {{- toYaml .Values.kubecost | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: kubecost
   syncPolicy:
     automated:

--- a/chart/templates/kubecost.yaml
+++ b/chart/templates/kubecost.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: kubecost
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/kubecost.yaml
+++ b/chart/templates/kubecost.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/kubecost

--- a/chart/templates/kubernetes-dashboard.yaml
+++ b/chart/templates/kubernetes-dashboard.yaml
@@ -20,7 +20,7 @@ spec:
       - name: kubernetes-dashboard.serviceAccount.name
         value: {{ .Values.kubernetesDashboard.serviceAccountName }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: kube-system
   syncPolicy:
     automated:

--- a/chart/templates/kubernetes-dashboard.yaml
+++ b/chart/templates/kubernetes-dashboard.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/kubernetes-dashboard

--- a/chart/templates/kubernetes-dashboard.yaml
+++ b/chart/templates/kubernetes-dashboard.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: kubernetes-dashboard
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/metrics-server.yaml
+++ b/chart/templates/metrics-server.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: {{ .Values.clusterName }}-metrics-server
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/metrics-server.yaml
+++ b/chart/templates/metrics-server.yaml
@@ -17,7 +17,7 @@ spec:
         metrics-server:
         {{- toYaml .Values.metricsServer | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: kube-system
   syncPolicy:
     automated:

--- a/chart/templates/metrics-server.yaml
+++ b/chart/templates/metrics-server.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/metrics-server

--- a/chart/templates/metrics-server.yaml
+++ b/chart/templates/metrics-server.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: metrics-server
+  name: {{ .Values.clusterName }}-metrics-server
   namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io

--- a/chart/templates/metrics-server.yaml
+++ b/chart/templates/metrics-server.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: {{ .Values.clusterName }}-metrics-server
+  name: metrics-server
   namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io

--- a/chart/templates/nvidia-device-plugin.yaml
+++ b/chart/templates/nvidia-device-plugin.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: nvidia-device-plugin
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/nvidia-device-plugin.yaml
+++ b/chart/templates/nvidia-device-plugin.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/nvidia-device-plugin

--- a/chart/templates/nvidia-device-plugin.yaml
+++ b/chart/templates/nvidia-device-plugin.yaml
@@ -17,7 +17,7 @@ spec:
         nvidia-device-plugin:
         {{- toYaml .Values.nvidiaDevicePlugin | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: nvidia-device-plugin
   syncPolicy:
     automated:

--- a/chart/templates/ondat.yaml
+++ b/chart/templates/ondat.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: ondat
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/ondat.yaml
+++ b/chart/templates/ondat.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/ondat

--- a/chart/templates/ondat.yaml
+++ b/chart/templates/ondat.yaml
@@ -74,7 +74,7 @@ spec:
           value: {{ .Values.ondat.etcdNodeSelectorTermValue }}
         {{- end }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: ondat
   syncPolicy:
     automated:

--- a/chart/templates/opentelemetry-collector.yaml
+++ b/chart/templates/opentelemetry-collector.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: opentelemetry-collector
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/opentelemetry-collector.yaml
+++ b/chart/templates/opentelemetry-collector.yaml
@@ -16,7 +16,7 @@ spec:
       valueFiles:
       - values.yaml
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: opentelemetry-collector
   syncPolicy:
     automated:

--- a/chart/templates/opentelemetry-collector.yaml
+++ b/chart/templates/opentelemetry-collector.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/opentelemetry-collector

--- a/chart/templates/prom-node-exporter.yaml
+++ b/chart/templates/prom-node-exporter.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/prometheus-node-exporter

--- a/chart/templates/prom-node-exporter.yaml
+++ b/chart/templates/prom-node-exporter.yaml
@@ -20,7 +20,7 @@ spec:
       - name: prometheus-node-exporter.serviceAccount.name
         value: {{ .Values.promtheusNodeExporter.serviceAccountName }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: prometheus-node-exporter
   syncPolicy:
     automated:

--- a/chart/templates/prom-node-exporter.yaml
+++ b/chart/templates/prom-node-exporter.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: prometheus-node-exporter
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/prometheus.yaml
+++ b/chart/templates/prometheus.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/prometheus

--- a/chart/templates/prometheus.yaml
+++ b/chart/templates/prometheus.yaml
@@ -32,7 +32,7 @@ spec:
         value: {{ .Values.region }}
       {{ end }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: prometheus
   syncPolicy:
     automated:

--- a/chart/templates/prometheus.yaml
+++ b/chart/templates/prometheus.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: prometheus
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/promtail.yaml
+++ b/chart/templates/promtail.yaml
@@ -17,7 +17,7 @@ spec:
         promtail:
         {{- toYaml .Values.promtail | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: promtail
   syncPolicy:
     automated:

--- a/chart/templates/promtail.yaml
+++ b/chart/templates/promtail.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: promtail
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/promtail.yaml
+++ b/chart/templates/promtail.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/promtail

--- a/chart/templates/reloader.yaml
+++ b/chart/templates/reloader.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/reloader

--- a/chart/templates/reloader.yaml
+++ b/chart/templates/reloader.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: reloader
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/reloader.yaml
+++ b/chart/templates/reloader.yaml
@@ -17,7 +17,7 @@ spec:
         reloader:
         {{- toYaml .Values.reloader | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: kube-system
   syncPolicy:
     automated:

--- a/chart/templates/smb-sci-driver.yaml
+++ b/chart/templates/smb-sci-driver.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/smb-csi-driver

--- a/chart/templates/smb-sci-driver.yaml
+++ b/chart/templates/smb-sci-driver.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: smb-csi-driver
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/smb-sci-driver.yaml
+++ b/chart/templates/smb-sci-driver.yaml
@@ -17,7 +17,7 @@ spec:
         smb-csi-driver:
         {{- toYaml .Values.smbCsiDriver | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: kube-system
   syncPolicy:
     automated:

--- a/chart/templates/spark-operator.yaml
+++ b/chart/templates/spark-operator.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/spark-operator

--- a/chart/templates/spark-operator.yaml
+++ b/chart/templates/spark-operator.yaml
@@ -17,7 +17,7 @@ spec:
         spark-operator:
         {{- toYaml .Values.sparkOperator | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: spark-operator
   syncPolicy:
     automated:

--- a/chart/templates/spark-operator.yaml
+++ b/chart/templates/spark-operator.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: spark-operator
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/strimzi-kafka-operator.yaml
+++ b/chart/templates/strimzi-kafka-operator.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: strimzi-kafka-operator
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/strimzi-kafka-operator.yaml
+++ b/chart/templates/strimzi-kafka-operator.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/strimzi-kafka-operator

--- a/chart/templates/strimzi-kafka-operator.yaml
+++ b/chart/templates/strimzi-kafka-operator.yaml
@@ -17,7 +17,7 @@ spec:
         strimzi-kafka-operator:
         {{- toYaml .Values.strimziKafkaOperator | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: strimzi
   syncPolicy:
     automated:

--- a/chart/templates/tetrate-istio.yaml
+++ b/chart/templates/tetrate-istio.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/tetrate-istio

--- a/chart/templates/tetrate-istio.yaml
+++ b/chart/templates/tetrate-istio.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: tetrate-istio
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/tetrate-istio.yaml
+++ b/chart/templates/tetrate-istio.yaml
@@ -23,7 +23,7 @@ spec:
         global:
         {{- toYaml .Values.tetrateIstio.global | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: istio-system
   syncPolicy:
     automated:

--- a/chart/templates/thanos.yaml
+++ b/chart/templates/thanos.yaml
@@ -17,7 +17,7 @@ spec:
         thanos:
         {{- toYaml .Values.thanos | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: thanos
   syncPolicy:
     automated:

--- a/chart/templates/thanos.yaml
+++ b/chart/templates/thanos.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: thanos
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/thanos.yaml
+++ b/chart/templates/thanos.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/thanos

--- a/chart/templates/traefik.yaml
+++ b/chart/templates/traefik.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: traefik
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/traefik.yaml
+++ b/chart/templates/traefik.yaml
@@ -17,7 +17,7 @@ spec:
         traefik:
         {{- toYaml .Values.traefik | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: traefik
   syncPolicy:
     automated:

--- a/chart/templates/traefik.yaml
+++ b/chart/templates/traefik.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/traefik

--- a/chart/templates/vault.yaml
+++ b/chart/templates/vault.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ required "repoUrl value is required" .Values.repoUrl }}
     path: add-ons/vault

--- a/chart/templates/vault.yaml
+++ b/chart/templates/vault.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: vault
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/vault.yaml
+++ b/chart/templates/vault.yaml
@@ -16,7 +16,7 @@ spec:
       values: |
         {{- toYaml .Values.vault | nindent 8 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: vault
   syncPolicy:
     automated:

--- a/chart/templates/velero.yaml
+++ b/chart/templates/velero.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: velero
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/velero.yaml
+++ b/chart/templates/velero.yaml
@@ -17,7 +17,7 @@ spec:
         velero:
         {{- toYaml .Values.velero | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: velero
   syncPolicy:
     automated:

--- a/chart/templates/velero.yaml
+++ b/chart/templates/velero.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/velero

--- a/chart/templates/vpa.yaml
+++ b/chart/templates/vpa.yaml
@@ -17,7 +17,7 @@ spec:
         vpa:
         {{- toYaml .Values.vpa | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: vpa
   syncPolicy:
     automated:

--- a/chart/templates/vpa.yaml
+++ b/chart/templates/vpa.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/vpa

--- a/chart/templates/vpa.yaml
+++ b/chart/templates/vpa.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: vpa
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/templates/yunikorn.yaml
+++ b/chart/templates/yunikorn.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: {{ .Values.argoProject | default "default" }}
   source:
     repoURL: {{ .Values.repoUrl }}
     path: add-ons/yunikorn

--- a/chart/templates/yunikorn.yaml
+++ b/chart/templates/yunikorn.yaml
@@ -17,7 +17,7 @@ spec:
         yunikorn:
         {{- toYaml .Values.yunikorn | nindent 10 }}
   destination:
-    server: https://kubernetes.default.svc
+    server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: yunikorn
   syncPolicy:
     automated:

--- a/chart/templates/yunikorn.yaml
+++ b/chart/templates/yunikorn.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: yunikorn
-  namespace: argocd
+  namespace: {{ .Values.argoNamespace | default "argocd" }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,6 +6,7 @@ account: ''
 clusterName: ''
 destinationServer: ''
 argoNamespace: ''
+argoProject: ''
 
 # Agones Values
 agones: 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,6 +4,7 @@ targetRevision: HEAD
 region: ''
 account: ''
 clusterName: ''
+destinationServer: ''
 
 # Agones Values
 agones: 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -45,6 +45,12 @@ awsLoadBalancerController:
   serviceAccountName:
   podDisruptionBudget:
     maxUnavailable: 1
+  respectIgnoreDifferences: true
+  ignoreDifferences:
+  - group: ""
+    kind: "Secret"
+    jsonPointers:
+    - /data
 
 # AWS Node Termination Handler Values
 awsNodeTerminationHandler:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,6 +5,7 @@ region: ''
 account: ''
 clusterName: ''
 destinationServer: ''
+argoNamespace: ''
 
 # Agones Values
 agones: 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -51,6 +51,14 @@ awsLoadBalancerController:
     kind: "Secret"
     jsonPointers:
     - /data
+  - group: "admissionregistration.k8s.io"
+    kind: "MutatingWebhookConfiguration"
+    jqPathExpressions:
+    - '.webhooks[]?.clientConfig.caBundle'
+  - group: "admissionregistration.k8s.io"
+    kind: "ValidatingWebhookConfiguration"
+    jqPathExpressions:
+    - '.webhooks[]?.clientConfig.caBundle'
 
 # AWS Node Termination Handler Values
 awsNodeTerminationHandler:


### PR DESCRIPTION
Closes https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1425

*Description of changes:*
This change is required to support the [PR for ArgoCD Multi-Cluster](https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1425) example
- It allows to override for the ArgoCD Apps the namespace, project, and destination server/cluster
- It fixes the sync warning for AWS ALB ArgoCD app by adding ignores for generates ssl cert related artifacts

All changes are backwards compatible with current examples of EKS Blueprints by using default fallbacks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
