### PR TITLE
fix(kube-prometheus-stack): Configurable repoURL

### DIFF
--- a/chart/templates/kube-prometheus-stack.yaml
+++ b/chart/templates/kube-prometheus-stack.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/aws-samples/eks-blueprints-add-ons
+    repoURL: {{ .Values.repoUrl }}
     path: add-ons/kube-prometheus-stack
     targetRevision: {{ .Values.targetRevision }}
     helm:


### PR DESCRIPTION
Among other templates only kube-prometheus-stack has hard-coded repoURL. This commit is to fix it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
