### PR TITLE
feat(cert-manager): Add cert-manager-ca and cert-manager-letsencrypt

### DIFF
--- a/add-ons/cert-manager/Chart.yaml
+++ b/add-ons/cert-manager/Chart.yaml
@@ -15,3 +15,9 @@ dependencies:
 - name: cert-manager
   version: v1.8.0
   repository: https://charts.jetstack.io
+- name: cert-manager-ca
+  version: 0.2.0
+  condition: cert-manager-ca.enabled
+- name: cert-manager-letsencrypt
+  version: 0.1.0
+  condition: cert-manager-letsencrypt.enabled

--- a/add-ons/cert-manager/charts/cert-manager-ca/Chart.yaml
+++ b/add-ons/cert-manager/charts/cert-manager-ca/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: cert-manager-ca
+description: A Helm chart to install a Cert Manager CA
+type: application
+version: 0.2.0
+appVersion: v0.1.0

--- a/add-ons/cert-manager/charts/cert-manager-ca/templates/certificate.yaml
+++ b/add-ons/cert-manager/charts/cert-manager-ca/templates/certificate.yaml
@@ -1,0 +1,21 @@
+{{- range .Values.clusterIssuers }}
+{{- if eq .type "CA" }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  isCA: true
+  commonName: {{ .name }}
+  secretName: {{ .secretName }}
+  {{- with .privateKey }}
+  privateKey:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .issuer }}
+  issuerRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/add-ons/cert-manager/charts/cert-manager-ca/templates/clusterissuers.yaml
+++ b/add-ons/cert-manager/charts/cert-manager-ca/templates/clusterissuers.yaml
@@ -1,0 +1,14 @@
+{{- range .Values.clusterIssuers }}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: {{ .name }}
+spec:
+  {{- if eq .type "selfSigned" }}
+  selfSigned: {}
+  {{- else if eq .type "CA" }}
+  ca:
+    secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}

--- a/add-ons/cert-manager/charts/cert-manager-ca/values.yaml
+++ b/add-ons/cert-manager/charts/cert-manager-ca/values.yaml
@@ -1,0 +1,13 @@
+clusterIssuers:
+  - name: cert-manager-selfsigned
+    type: selfSigned
+  - name: cert-manager-ca
+    type: CA
+    secretName: cert-manager-ca-root
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    issuer:
+      name: cert-manager-selfsigned
+      kind: ClusterIssuer
+      group: cert-manager.io

--- a/add-ons/cert-manager/charts/cert-manager-letsencrypt/Chart.yaml
+++ b/add-ons/cert-manager/charts/cert-manager-letsencrypt/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: cert-manager-letsencrypt
+description: Cert Manager Cluster Issuers for Let's Encrypt certificates with DNS01 protocol
+type: application
+version: 0.1.0
+appVersion: v0.1.0

--- a/add-ons/cert-manager/charts/cert-manager-letsencrypt/templates/clusterissuer-production.yaml
+++ b/add-ons/cert-manager/charts/cert-manager-letsencrypt/templates/clusterissuer-production.yaml
@@ -1,0 +1,27 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: {{ .Release.Name }}-production-route53
+  labels:
+    ca: letsencrypt
+    environment: production
+    solver: dns01
+    provider: route53
+spec:
+  acme:
+    {{- if .Values.email }}
+    email: {{ .Values.email }}
+    {{- end }}
+    server: https://acme-v02.api.letsencrypt.org/directory
+    preferredChain: ISRG Root X1
+    privateKeySecretRef:
+      name: {{ .Release.Name }}-production-route53
+    solvers:
+      - dns01:
+          route53:
+            region: {{ .Values.region | default "global" }}
+        {{- if .Values.dnsZones }}
+        selector:
+          dnsZones:
+            {{- .Values.dnsZones | toYaml | nindent 12 }}
+        {{- end }}

--- a/add-ons/cert-manager/charts/cert-manager-letsencrypt/templates/clusterissuer-staging.yaml
+++ b/add-ons/cert-manager/charts/cert-manager-letsencrypt/templates/clusterissuer-staging.yaml
@@ -1,0 +1,27 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: {{ .Release.Name }}-staging-route53
+  labels:
+    ca: letsencrypt
+    environment: staging
+    solver: dns01
+    provider: route53
+spec:
+  acme:
+    {{- if .Values.email }}
+    email: {{ .Values.email }}
+    {{- end }}
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    preferredChain: ISRG Root X1
+    privateKeySecretRef:
+      name: {{ .Release.Name }}-staging-route53
+    solvers:
+      - dns01:
+          route53:
+            region: {{ .Values.region | default "global" }}
+        {{- if .Values.dnsZones }}
+        selector:
+          dnsZones:
+            {{- .Values.dnsZones | toYaml | nindent 12 }}
+        {{- end }}

--- a/add-ons/cert-manager/charts/cert-manager-letsencrypt/values.yaml
+++ b/add-ons/cert-manager/charts/cert-manager-letsencrypt/values.yaml
@@ -1,0 +1,6 @@
+# email: user@example.com
+
+# region: global
+
+# dnsZones:
+# - domain.name

--- a/add-ons/cert-manager/values.yaml
+++ b/add-ons/cert-manager/values.yaml
@@ -4,3 +4,11 @@ cert-manager:
   installCRDs: true
   serviceAccount:
     create: false
+
+cert-manager-ca:
+  enabled: true
+
+cert-manager-letsencrypt:
+  enabled: false
+  email:
+  dnsZones:

--- a/chart/templates/cert-manager.yaml
+++ b/chart/templates/cert-manager.yaml
@@ -16,6 +16,10 @@ spec:
       values: |
         cert-manager:
         {{- toYaml .Values.certManager | nindent 10 }}
+        cert-manager-ca:
+        {{- toYaml .Values.certManager.certManagerCa | nindent 10 }}
+        cert-manager-letsencrypt:
+        {{- toYaml .Values.certManager.certManagerLetsencrypt | nindent 10 }}
       parameters:
       - name: cert-manager.serviceAccount.name
         value: {{ .Values.certManager.serviceAccountName }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -79,6 +79,12 @@ certManager:
   enable: false
   createNamespace: true
   serviceAccountName:
+  certManagerCa:
+    enabled: true
+  certManagerLetsencrypt:
+    enabled: false
+    email:
+    dnsZones:
 
 # Cert Manager CSI Driver Values
 certManagerCsiDriver:


### PR DESCRIPTION

*Issue #, if available:*

fixes: #127
Related: https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1530


*Description of changes:*


As stated in https://github.com/aws-samples/eks-blueprints-add-ons/issues/127 blueprint terraform allows installing Issuer CA and LetsEncrypt Issuer, however, when those settings are gone when GitOps is enabled.

This commit enables installing those issuers by using subchart.

The subcharts are copied from the terraform-aws-eks-blueprint modules:
- https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/kubernetes-addons/cert-manager/cert-manager-ca
- https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/kubernetes-addons/cert-manager/cert-manager-letsencrypt

The values are configred in blueprint here:
- https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/12e43950ab56eaba44307e14739d4860edd1511f/modules/kubernetes-addons/cert-manager/locals.tf#L47-L50

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
