### PR TITLE
fix: bump aws-for-fluent-bit version as psp not available in 1.25

### DIFF
--- a/add-ons/aws-for-fluent-bit/Chart.yaml
+++ b/add-ons/aws-for-fluent-bit/Chart.yaml
@@ -16,5 +16,5 @@ appVersion: "1.0"
 
 dependencies:
 - name: aws-for-fluent-bit
-  version: 0.1.17
+  version: 0.1.24
   repository: https://aws.github.io/eks-charts


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since psp are not existing anymore in eks 1.25, we need to disable PSP from aws-for-fluent-bit.

The new version of the chart already take this into account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
