### PR TITLE
Fix: Helm values with correct key names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ spec:
     helm:
       release: add-ons
       values: |
-        cluster-autoscaler:
+        clusterAutoscaler:
           enable: true
-        metrics-server:
+        metrics:
           enable: true
   destination:
     server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}


### PR DESCRIPTION
*Description of issue:*

I have tried the sample of app of apps yaml but looks like the values provided to helm are not correct .

```yaml
    path: chart
    helm:
      release:   add-ons
      values: |
        cluster-autoscaler:
          enable: true
        metrics-server:
          enable: true
```

i can deploy it successfully  the apps are not showing , i have checked the values.yml in https://github.com/aws-samples/eks-blueprints-add-ons/blob/main/chart/values.yaml#L88 

you will see :

```yaml
# Cluster Autoscaler Values
clusterAutoscaler:
  enable: false
  serviceAccountName:`
```
So correct values show be : 
```yaml 
  targetRevision: HEAD
    path: chart
    helm:
      release: add-ons
      values: |
        clusterAutoscaler:
          enable: true
        metricsServer:
          enable: true
```
