### PR TITLE
removing GoTemplate missingkey=error, so that we can rely on default …

### DIFF
--- a/argocd/bootstrap/control-plane/addons/aws/addons-aws-oss-external-dns-appset.yaml
+++ b/argocd/bootstrap/control-plane/addons/aws/addons-aws-oss-external-dns-appset.yaml
@@ -5,7 +5,6 @@ metadata:
   name: addons-aws-external-dns
 spec:
   goTemplate: true
-  goTemplateOptions: ['missingkey=error']
   syncPolicy:
     preserveResourcesOnDeletion: true
   generators:

--- a/argocd/bootstrap/control-plane/addons/oss/addons-ingress-nginx-appset.yaml
+++ b/argocd/bootstrap/control-plane/addons/oss/addons-ingress-nginx-appset.yaml
@@ -5,7 +5,6 @@ metadata:
   name: addons-ingress-nginx
 spec:
   goTemplate: true
-  goTemplateOptions: ['missingkey=error']
   syncPolicy:
     preserveResourcesOnDeletion: true
   generators:


### PR DESCRIPTION
…syntaxe

*Issue #, if available:* Fix #161

*Description of changes:*

We want to use GoTemplate with default values, without him complaining that some keys may be missing


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
