### PR TITLE
Only set the single zoneIdFilters[0] if a value exists

### DIFF
--- a/chart/templates/external-dns.yaml
+++ b/chart/templates/external-dns.yaml
@@ -21,8 +21,10 @@ spec:
         value: {{ .Values.region }}
       - name: external-dns.serviceAccount.name
         value: {{ .Values.externalDns.serviceAccountName }}
+      {{- if .Values.externalDns.zoneIdFilter -}}
       - name: external-dns.zoneIdFilters[0]
         value: {{ .Values.externalDns.zoneIdFilter }}
+      {{- end -}}
   destination:
     server: {{ .Values.destinationServer | default "https://kubernetes.default.svc" }}
     namespace: external-dns


### PR DESCRIPTION
This makes the external-dns chart not break on server-side apply.

I was getting an issue with the null value for this field that the chart was setting when not using the `zoneIdFilter` field it was asking for, and instead using either `zoneIdFilters` (with multiple zones) or `domainFilters`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
